### PR TITLE
내 정보 조회, 수정 리팩토링 및 로그아웃 기능 구현

### DIFF
--- a/backend/src/main/java/com/project/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/project/backend/domain/member/controller/MemberController.java
@@ -94,9 +94,9 @@ public class MemberController {
      */
     @GetMapping("/mine")
     @Operation(summary = "회원 정보 조회")
-    public ResponseEntity<GenericResponse<MemberDto>> getMyProfile(
+    public ResponseEntity<GenericResponse<MineDto>> getMyProfile(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        MemberDto myProfile = memberService.getMyProfile(userDetails.getUsername());
+        MineDto myProfile = memberService.getMyProfile(userDetails.getUsername());
 
         return ResponseEntity.ok(GenericResponse.of(myProfile, "회원 정보 조회 성공"));
     }

--- a/backend/src/main/java/com/project/backend/domain/member/dto/MemberDto.java
+++ b/backend/src/main/java/com/project/backend/domain/member/dto/MemberDto.java
@@ -1,5 +1,6 @@
 package com.project.backend.domain.member.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.project.backend.domain.member.entity.Member;
 import jakarta.validation.constraints.NotBlank;
@@ -21,6 +22,7 @@ import org.hibernate.validator.constraints.Length;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class MemberDto extends MineDto {
     @JsonProperty
     private long id;

--- a/backend/src/main/java/com/project/backend/domain/member/dto/MemberDto.java
+++ b/backend/src/main/java/com/project/backend/domain/member/dto/MemberDto.java
@@ -1,5 +1,6 @@
 package com.project.backend.domain.member.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.project.backend.domain.member.entity.Member;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -21,16 +22,19 @@ import org.hibernate.validator.constraints.Length;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MemberDto extends MineDto {
+    @JsonIgnore
     private long id;
 
     @NotBlank
     @Length(min = 2, max = 16)
     private String username;
 
+    @JsonIgnore
     @NotBlank
     @Length(min = 8)
     private String password1;
 
+    @JsonIgnore
     @NotBlank
     private String password2;
 

--- a/backend/src/main/java/com/project/backend/domain/member/dto/MemberDto.java
+++ b/backend/src/main/java/com/project/backend/domain/member/dto/MemberDto.java
@@ -1,6 +1,6 @@
 package com.project.backend.domain.member.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.project.backend.domain.member.entity.Member;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -22,19 +22,19 @@ import org.hibernate.validator.constraints.Length;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MemberDto extends MineDto {
-    @JsonIgnore
+    @JsonProperty
     private long id;
 
     @NotBlank
     @Length(min = 2, max = 16)
     private String username;
 
-    @JsonIgnore
+    @JsonProperty
     @NotBlank
     @Length(min = 8)
     private String password1;
 
-    @JsonIgnore
+    @JsonProperty
     @NotBlank
     private String password2;
 

--- a/backend/src/main/java/com/project/backend/domain/member/dto/MineDto.java
+++ b/backend/src/main/java/com/project/backend/domain/member/dto/MineDto.java
@@ -17,15 +17,13 @@ import java.time.LocalDate;
  */
 @Getter
 public class MineDto {
-    String password;
+    @NotBlank
+    @Length(min = 2, max = 20)
+    String nickname;
 
     @NotBlank
     @Email
     String email;
-
-    @NotBlank
-    @Length(min = 2, max = 20)
-    String nickname;
 
     int gender;
 

--- a/backend/src/main/java/com/project/backend/global/jwt/JwtAuthentizationFilter.java
+++ b/backend/src/main/java/com/project/backend/global/jwt/JwtAuthentizationFilter.java
@@ -65,8 +65,7 @@ public class JwtAuthentizationFilter extends OncePerRequestFilter {
 
     /**
      * 요청 헤더에서 JWT 토큰을 추출하는 메서드
-     * 1. Authorization 헤더에서 Bearer <token> 형식으로 추출
-     * 2. 쿠키에서 accessToken 추출
+     * 쿠키에서 accessToken 추출
      *
      * @param request HTTP 요청
      * @return 토큰 문자열, 없으면 null

--- a/backend/src/main/java/com/project/backend/global/jwt/JwtAuthentizationFilter.java
+++ b/backend/src/main/java/com/project/backend/global/jwt/JwtAuthentizationFilter.java
@@ -11,7 +11,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -45,7 +44,7 @@ public class JwtAuthentizationFilter extends OncePerRequestFilter {
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
         // 요청에서 토큰 추출
-        String token = getTokenFromRequest(request);
+        String token = getJwtFromCookies(request);
 
         // 토큰이 존재하고 유효하다면, 사용자 정보를 SecurityContext에 설정
         if (token != null && jwtUtil.validateToken(token)) {
@@ -72,15 +71,7 @@ public class JwtAuthentizationFilter extends OncePerRequestFilter {
      * @param request HTTP 요청
      * @return 토큰 문자열, 없으면 null
      */
-    private String getTokenFromRequest(HttpServletRequest request) {
-        // 1. Authorization 헤더에서 Bearer <token> 형식으로 추출
-        String bearerToken = request.getHeader("Authorization");
-        // Bearer <token> 형식의 토큰만 추출
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7);
-        }
-
-        // 2. 쿠키에서 accessToken 추출
+    private String getJwtFromCookies(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             for (Cookie cookie : cookies) {

--- a/backend/src/main/java/com/project/backend/global/jwt/JwtAuthentizationFilter.java
+++ b/backend/src/main/java/com/project/backend/global/jwt/JwtAuthentizationFilter.java
@@ -2,6 +2,7 @@ package com.project.backend.global.jwt;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -64,17 +65,31 @@ public class JwtAuthentizationFilter extends OncePerRequestFilter {
     }
 
     /**
-     * 요청 헤더에서 Authorization 토큰을 추출하는 메서드
+     * 요청 헤더에서 JWT 토큰을 추출하는 메서드
+     * 1. Authorization 헤더에서 Bearer <token> 형식으로 추출
+     * 2. 쿠키에서 accessToken 추출
      *
      * @param request HTTP 요청
      * @return 토큰 문자열, 없으면 null
      */
     private String getTokenFromRequest(HttpServletRequest request) {
+        // 1. Authorization 헤더에서 Bearer <token> 형식으로 추출
         String bearerToken = request.getHeader("Authorization");
         // Bearer <token> 형식의 토큰만 추출
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
             return bearerToken.substring(7);
         }
+
+        // 2. 쿠키에서 accessToken 추출
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("accessToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+
         return null;
     }
 }


### PR DESCRIPTION
## 📌 과제 설명
- 멤버에서 내 정보 조회 및 수정 로직을 리팩토링하였고, 로그아웃 기능을 구현하였습니다.

## 👩‍💻 요구 사항과 구현 내용
- JWT 토큰을 헤더의 Set-Cookies 에 넣어 처리하는 방식으로 구현하였습니다.
  - 이렇게 하여 로그인 후 수동으로 토큰을 넣지 않고, 로그인 하면 자동적으로 토큰 처리가 가능합니다.
- 로그아웃 기능을 구현하여 로그아웃 시에 발급된 액세스 토큰을 초기화 시켰습니다.

## ✅ 피드백 반영사항

## ✅ PR 포인트 & 궁금한 점
- 현재 멘토링 시 피드백 내용은 아직 수정되지 않았습니다.(setter 제거 등)
  - 이 PR이 Merge된 후에 작업할 예정입니다.
  - 추가로 회원 탈퇴 로직 또한 같이 작업할 예정입니다. 